### PR TITLE
Don't escape markdown filter's markup

### DIFF
--- a/springboard/filters.py
+++ b/springboard/filters.py
@@ -8,6 +8,7 @@ from markdown import markdown
 
 from pyramid.threadlocal import get_current_registry
 
+from jinja2 import Markup
 from babel import Locale
 from pycountry import languages
 
@@ -40,7 +41,7 @@ def thumbor_filter(ctx, image, width, height=None):
 def markdown_filter(ctx, content):
     if not content:
         return content
-    return markdown(content)
+    return Markup(markdown(content))
 
 
 @contextfilter

--- a/springboard/tests/test_filters.py
+++ b/springboard/tests/test_filters.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from pyramid import testing
 
+from jinja2 import Markup
 from libthumbor import CryptoURL
 
 from springboard.tests import SpringboardTestCase
@@ -47,8 +48,10 @@ class TestFilters(SpringboardTestCase):
             thumbor_filter({}, 'image', 25), '')
 
     def test_markdown_filter(self):
+        result = markdown_filter({}, '*foo*')
+        self.assertIsInstance(result, Markup)
         self.assertEqual(
-            markdown_filter({}, '*foo*'),
+            result,
             '<p><em>foo</em></p>')
 
     def test_markdown_filter_none(self):


### PR DESCRIPTION
pyramid_jinja2 [turns autoescaping on](http://docs.pylonsproject.org/projects/pyramid-jinja2/en/latest/#jinja2-autoescape). So the markdown filter needs to return a safe string.
