### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Springboard
     :target: https://springboard.readthedocs.org
     :alt: Springboard Documentation
 
-.. image:: https://pypip.in/version/springboard/badge.svg
+.. image:: https://img.shields.io/pypi/v/springboard.svg
     :target: https://pypi.python.org/pypi/springboard
     :alt: Pypi Package
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20springboard))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `springboard`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.